### PR TITLE
Can now be installed via NPM and used with Browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Please file any issues and bugs in our main repository at [angular-translate/ang
 $ bower install angular-translate-storage-cookie
 ```
 
+### via NPM
+```bash
+$ npm install angular-translate-storage-cookie
+```
+
 ### via cdnjs
 
 Please have a look at https://cdnjs.com/libraries/angular-translate-stroage-cookie for specific versions.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "angular-translate-storage-cookie",
+  "version": "2.7.0",
+  "description": "Abstraction layer for cookieStore. This service is used when telling angular-translate to use cookieStore as storage.",
+  "main": "angular-translate-storage-cookie.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular-translate/bower-angular-translate-storage-cookie.git"
+  },
+  "keywords": [
+    "angular",
+    "angular-translate",
+    "angular-translate-storage-cookie"
+  ],
+  "author": "Pascal Precht",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/angular-translate/bower-angular-translate-storage-cookie/issues"
+  },
+  "homepage": "https://github.com/angular-translate/bower-angular-translate-storage-cookie"
+}


### PR DESCRIPTION
Added PACKAGE.JSON to allow installing angular-translate-storage-cookie using NPM, enabling proper Browserification in the process.
